### PR TITLE
A great SearchBar that doesn't whiff out my data plan while I typing!

### DIFF
--- a/client/src/SearchBar.js
+++ b/client/src/SearchBar.js
@@ -19,7 +19,7 @@ function SearchBar(props) {
   } = props;
   const location = useLocation();
   const history = useHistory();
-  useEffect(() => {
+  const doSearch = () => {
     const url = new URL(window.location);
     url.searchParams.set('q', query);
     // updates url query param based on search term
@@ -49,6 +49,12 @@ function SearchBar(props) {
       window.history.pushState({}, '', url);
       document.querySelector('input[type="text"]').value = '';
     }
+  };
+  // Debounce the doSearch function to only run when the user stops typing for 200ms
+  // Ref: https://typeofnan.dev/debouncing-with-react-hooks/
+  useEffect(() => {
+    const timer = setTimeout(doSearch, 200);
+    return () => clearTimeout(timer);
   }, [query, location]);
   const onChange = (e) => {
     // live search, sets query as text in search bar changes

--- a/routes/screenshots.js
+++ b/routes/screenshots.js
@@ -22,7 +22,7 @@ router.get('/', (req, res) => {
                 BETWEEN subtitles.time_start
                 AND subtitles.time_end
                 WHERE subtitles.episode = screenshots.episode
-                AND subtitles.text ILIKE $1`,
+                AND subtitles.text ILIKE $1 LIMIT 100`,
   [`%${scrubbedSearch}%`], (error, results) => {
     if (error) {
       throw error;


### PR DESCRIPTION
Has this ever happened to you? You search for "whiff", but the SearchBar searches for "whi", "whif", and "whiff" in quick succession? And when the "whi" response finally shows up, it spends over 30 seconds fetching 166 screenshots, which uses 11MB and prevents further searches until those 166 requests complete?

The reason is that the searchbar doesn't "debounce" as the user types. So every extra letter typed after 3 letters triggers a new search and a new set of images to download.

This PR will prevent calling the /screenshots API until the user stops typing for 200ms. And it limits the number of screenshots to 100.